### PR TITLE
lsコマンドの課題 -a, -r, -lオプションの統合

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,12 +11,7 @@ MULTIPLE_OF_COLUMN_WIDTH = 8
 def main
   options = parse_options
   files = acquire_files(a_option: options[:a], r_option: options[:r])
-  if options[:l]
-    puts generate_header_to_display(files)
-    puts generate_file_info_to_display(files)
-  else
-    puts generate_file_name_to_display(files)
-  end
+  generate_contents(files, l_option: options[:l])
 end
 
 def parse_options
@@ -147,6 +142,15 @@ end
 
 def generate_header_to_display(files)
   "total #{files.inject(0) { |total, file| total + File.lstat(file).blocks }}"
+end
+
+def generate_contents(files, l_option: false)
+  if l_option
+    puts generate_header_to_display(files)
+    puts generate_file_info_to_display(files)
+  else
+    puts generate_file_name_to_display(files)
+  end
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,7 +11,7 @@ MULTIPLE_OF_COLUMN_WIDTH = 8
 def main
   options = parse_options
   files = acquire_files(a_option: options[:a], r_option: options[:r])
-  generate_contents(files, l_option: options[:l])
+  display(files, l_option: options[:l])
 end
 
 def parse_options
@@ -144,7 +144,7 @@ def generate_header_to_display(files)
   "total #{files.inject(0) { |total, file| total + File.lstat(file).blocks }}"
 end
 
-def generate_contents(files, l_option: false)
+def display(files, l_option: false)
   if l_option
     puts generate_header_to_display(files)
     puts generate_file_info_to_display(files)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,6 +12,7 @@ def main
   options = parse_options
   files = acquire_files(a_option: options[:a], r_option: options[:r])
   if options[:l]
+    puts "total #{files.inject(0) { |total, file| total + File.lstat(file).blocks }}"
     puts generate_file_info_to_display(files)
   else
     puts generate_file_name_to_display(files)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,7 +12,7 @@ def main
   options = parse_options
   files = acquire_files(a_option: options[:a], r_option: options[:r])
   if options[:l]
-    puts "total #{files.inject(0) { |total, file| total + File.lstat(file).blocks }}"
+    puts generate_header_to_display(files)
     puts generate_file_info_to_display(files)
   else
     puts generate_file_name_to_display(files)
@@ -143,6 +143,10 @@ def generate_file_info_to_display(files)
     ]
     file_info.join(' ')
   end
+end
+
+def generate_header_to_display(files)
+  "total #{files.inject(0) { |total, file| total + File.lstat(file).blocks }}"
 end
 
 main


### PR DESCRIPTION
lオプションを指定したときに`total`のバイト数が表示されるように修正しました。